### PR TITLE
add ignoring dependencies by partial group

### DIFF
--- a/gradle-require-dependency-compliance-plugin/src/main/java/de/acetous/dependencycompliance/export/DependencyFilterService.java
+++ b/gradle-require-dependency-compliance-plugin/src/main/java/de/acetous/dependencycompliance/export/DependencyFilterService.java
@@ -37,7 +37,7 @@ public class DependencyFilterService {
 
     public boolean isIgnored(DependencyIdentifier dependencyIdentifier, Set<DependencyIdentifier> dependencyFilter) {
         return dependencyFilter.stream() //
-                .anyMatch(ignore -> ignoreMatchesComplete(dependencyIdentifier, ignore) || ignoreWithArtifactWildcardMatchesGroup(dependencyIdentifier, ignore) || ignoreWithVersionWildcardMatchesArtifact(dependencyIdentifier, ignore));
+                .anyMatch(ignore -> ignoreMatchesComplete(dependencyIdentifier, ignore) || ignoreWithArtifactWildcardMatchesGroup(dependencyIdentifier, ignore) || ignoreWithVersionWildcardMatchesArtifact(dependencyIdentifier, ignore) || ignoreWithPartialGroup(dependencyIdentifier, ignore));
     }
 
     private boolean ignoreWithVersionWildcardMatchesArtifact(DependencyIdentifier dependencyIdentifier, DependencyIdentifier ignore) {
@@ -50,5 +50,9 @@ public class DependencyFilterService {
 
     private boolean ignoreMatchesComplete(DependencyIdentifier dependencyIdentifier, DependencyIdentifier ignore) {
         return dependencyIdentifier.equals(ignore);
+    }
+
+    private boolean ignoreWithPartialGroup(DependencyIdentifier dependencyIdentifier, DependencyIdentifier ignore) {
+        return ignore.getVersion().equals("*") && ignore.getName().equals("*") && ignore.getGroup().endsWith("*") && dependencyIdentifier.getGroup().startsWith(ignore.getGroup().substring(0, ignore.getGroup().length()-1));
     }
 }

--- a/gradle-require-dependency-compliance-plugin/src/test/java/de/acetous/dependencycompliance/export/DependencyFilterServiceTest.java
+++ b/gradle-require-dependency-compliance-plugin/src/test/java/de/acetous/dependencycompliance/export/DependencyFilterServiceTest.java
@@ -65,11 +65,19 @@ public class DependencyFilterServiceTest {
         assertThat(testSubject.isIgnored(DependencyIdentifier.create("org", "bac", "4711"), Collections.emptySet())).isFalse();
     }
 
+    @Test
+    public void shouldFilterWithPartialGroup() {
+        assertThat(testSubject.isIgnored(DependencyIdentifier.create("com", "foo", "123"), createDependencyFilter())).isFalse();
+        assertThat(testSubject.isIgnored(DependencyIdentifier.create("com.foo", "bar", "42"), createDependencyFilter())).isFalse();
+        assertThat(testSubject.isIgnored(DependencyIdentifier.create("com.foo.bar", "bac", "4711"), createDependencyFilter())).isTrue();
+    }
+
     private Set<DependencyIdentifier> createDependencyFilter() {
         return new HashSet<>(Arrays.asList(
                 DependencyIdentifier.create("foo", "bar", "123"),
                 DependencyIdentifier.create("org", "baz", "*"),
-                DependencyIdentifier.create("de", "*", "*")
+                DependencyIdentifier.create("de", "*", "*"),
+                DependencyIdentifier.create("com.foo.*", "*", "*")
         ));
     }
 }


### PR DESCRIPTION
If the group of an ignored dependency end with an asterix,
this is considered a wildcard and all matching groups are ignored.
In this case the artifact and the version have to wildcard (*), too.